### PR TITLE
Chenge repo of external/cronet to lineageOS from aosp

### DIFF
--- a/snippets/pixys.xml
+++ b/snippets/pixys.xml
@@ -56,6 +56,7 @@
   <project path="external/libnl" name="external_libnl" remote="pixys" />
   <project path="external/gptfdisk" name="external_gptfdisk" remote="pixys" />
   <project path="external/mksh" name="external_mksh" remote="pixys" />
+  <project path="external/cronet" name="android_external_cronet" groups="pdk" remote="lineage" />
 
   <!-- Frameworks Repos -->
   <project path="frameworks/av" name="frameworks_av" remote="pixys" />

--- a/snippets/remove.xml
+++ b/snippets/remove.xml
@@ -86,6 +86,7 @@
   <remove-project name="platform/external/gptfdisk" />
   <remove-project name="platform/external/mksh" />
   <remove-project name="platform/external/libcxx" />
+  <remove-project name="platform/external/cronet" />
 
   <!-- General repos -->
   <remove-project name="platform/art" />


### PR DESCRIPTION
To avoid  error of failing command running inside an sbox sandbox, chenge repo of external/cronet to lineageOS from aosp.